### PR TITLE
fix: disable Spring Cloud GCP auto-configuration to prevent credentia…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,6 +14,12 @@ server.port=${PORT:8080}
 # Google Cloud Project ID
 spring.cloud.gcp.project-id=${SPRING_CLOUD_GCP_PROJECT_ID}
 
+# Deshabilitar completamente Spring Cloud GCP auto-configuración
+spring.cloud.gcp.core.enabled=false
+spring.cloud.gcp.autoconfigure.enabled=false
+spring.cloud.gcp.credentials.enabled=false
+spring.cloud.gcp.config.enabled=false
+
 # ================================================
 # CONFIGURACIÓN DE WEBHOOK Y TELEGRAM
 # ================================================


### PR DESCRIPTION
…ls file loading errors

- Completely disable Spring Cloud GCP auto-configuration
- Simplify FirebaseConfig to work directly with Google Cloud credentials
- Remove dependency on spring.cloud.gcp.credentials.location
- Fix deployment failures caused by missing credentials file