### PR TITLE
fix: exclude Firestore auto-configuration to prevent startup failures

### DIFF
--- a/src/main/java/com/politicalreferralswa/PoliticalReferralsWaApplication.java
+++ b/src/main/java/com/politicalreferralswa/PoliticalReferralsWaApplication.java
@@ -6,7 +6,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {
+    com.google.cloud.spring.autoconfigure.firestore.GcpFirestoreAutoConfiguration.class,
+    com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration.class,
+    com.google.cloud.spring.autoconfigure.core.GcpCoreAutoConfiguration.class
+})
 public class PoliticalReferralsWaApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
- Exclude GcpFirestoreAutoConfiguration from Spring Boot auto-configuration
- Exclude GcpContextAutoConfiguration and GcpCoreAutoConfiguration
- Prevent Spring from trying to create Firestore beans automatically
- Allow our custom FirebaseConfig to handle Firestore configuration