### PR TITLE
fix: correct Spring Cloud GCP exclusion class names for version 4.8.4

### DIFF
--- a/src/main/java/com/politicalreferralswa/PoliticalReferralsWaApplication.java
+++ b/src/main/java/com/politicalreferralswa/PoliticalReferralsWaApplication.java
@@ -8,8 +8,7 @@ import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication(exclude = {
     com.google.cloud.spring.autoconfigure.firestore.GcpFirestoreAutoConfiguration.class,
-    com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration.class,
-    com.google.cloud.spring.autoconfigure.core.GcpCoreAutoConfiguration.class
+    com.google.cloud.spring.autoconfigure.core.GcpContextAutoConfiguration.class
 })
 public class PoliticalReferralsWaApplication {
 


### PR DESCRIPTION
- Remove non-existent GcpCoreAutoConfiguration class
- Keep only GcpFirestoreAutoConfiguration and GcpContextAutoConfiguration
- Fix compilation error caused by incorrect class references