### PR TITLE
fix: change WatiApiService to read from environment variables instead…

### DIFF
--- a/src/main/java/com/politicalreferralswa/service/WatiApiService.java
+++ b/src/main/java/com/politicalreferralswa/service/WatiApiService.java
@@ -12,11 +12,11 @@ import java.time.Duration; // Importación para timeouts
 @Service
 public class WatiApiService {
 
-    @Value("${wati.api.endpoint.base}")
+    @Value("${WATI_API_ENDPOINT_BASE}")
     private String watiApiBaseEndpoint;
-    @Value("${wati.api.tenant-id}")
+    @Value("${WATI_TENANT_ID}")
     private String watiApiTenantId;
-    @Value("${wati.api.token}")
+    @Value("${WATI_API_TOKEN}")
     private String watiApiToken;
 
     private final WebClient webClient;


### PR DESCRIPTION
… of Spring properties

- Change @Value annotations from wati.api.* to WATI_* environment variables
- Fix tenant ID reading from WATI_TENANT_ID instead of wati.api.tenant-id
- Ensure secrets are used correctly in Cloud Run environment
- Fix 403 Forbidden error caused by wrong tenant ID (475711 vs 473173)