### PR TITLE
🔧 Fix Mixed Content Error: Add HTTPS server configuration to OpenAPI

### DIFF
--- a/src/main/java/com/politicalreferralswa/config/OpenApiConfig.java
+++ b/src/main/java/com/politicalreferralswa/config/OpenApiConfig.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,6 +29,9 @@ public class OpenApiConfig {
                                 .in(SecurityScheme.In.HEADER)
                                 .name("X-API-Key")
                                 .description("API Key requerida para acceder a los endpoints de control del sistema")))
-                .addSecurityItem(new SecurityRequirement().addList("ApiKeyAuth"));
+                .addSecurityItem(new SecurityRequirement().addList("ApiKeyAuth"))
+                .addServersItem(new Server()
+                        .url("https://political-referrals-wa-dev-331919709696.us-central1.run.app")
+                        .description("Servidor de desarrollo en Google Cloud Run"));
     }
 } 


### PR DESCRIPTION
- Add explicit HTTPS server URL to OpenApiConfig
- Fixes Swagger UI making HTTP requests to HTTPS site
- Prevents browser blocking requests due to mixed content
- Ensures all API calls use secure HTTPS protocol