### PR TITLE
🔧 Fix duplicate SYSTEM_API_KEY in CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -189,8 +189,7 @@ jobs:
             --set-secrets WATI_NOTIFICATION_ENABLED=wati-notification-enabled:latest \
             --set-secrets WATI_NOTIFICATION_GROUP_ID=wati-notification-group-id:latest \
             --set-secrets WATI_NOTIFICATION_PHONES=wati-notification-phones:latest \
-            --set-secrets SYSTEM_API_KEY=SYSTEM_API_KEY_DEV:latest \
-            --set-secrets SYSTEM_API_KEY=SYSTEM_API_KEY_PROD:latest
+            --set-secrets SYSTEM_API_KEY=SYSTEM_API_KEY_DEV:latest
         fi
           
     - name: Get service URL


### PR DESCRIPTION
- Remove duplicate SYSTEM_API_KEY configuration in development section
- Fixes 'cannot be specified multiple times' error during deployment
- Each environment now correctly maps to its respective secret:
  - DEV: SYSTEM_API_KEY_DEV:latest
  - PROD: SYSTEM_API_KEY_PROD:latest