### PR TITLE
🚀 Improve performance: Increase timeouts for Wati API calls

### DIFF
--- a/src/main/java/com/politicalreferralswa/config/WebClientConfig.java
+++ b/src/main/java/com/politicalreferralswa/config/WebClientConfig.java
@@ -31,10 +31,10 @@ public class WebClientConfig {
         // Configurar HttpClient con timeouts realistas y configuración SSL/TLS optimizada
         HttpClient httpClient = HttpClient.create(connectionProvider)
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000) // 10 segundos timeout de conexión
-                .responseTimeout(Duration.ofSeconds(25)) // 25 segundos timeout de respuesta
+                .responseTimeout(Duration.ofSeconds(60)) // 60 segundos timeout de respuesta
                 .doOnConnected(conn -> 
-                    conn.addHandlerLast(new ReadTimeoutHandler(25, TimeUnit.SECONDS)) // 25 segundos timeout de lectura
-                        .addHandlerLast(new WriteTimeoutHandler(25, TimeUnit.SECONDS)) // 25 segundos timeout de escritura
+                    conn.addHandlerLast(new ReadTimeoutHandler(60, TimeUnit.SECONDS)) // 60 segundos timeout de lectura
+                        .addHandlerLast(new WriteTimeoutHandler(60, TimeUnit.SECONDS)) // 60 segundos timeout de escritura
                 )
                 .keepAlive(true)
                 .compress(true)

--- a/src/main/java/com/politicalreferralswa/service/WatiApiService.java
+++ b/src/main/java/com/politicalreferralswa/service/WatiApiService.java
@@ -56,7 +56,7 @@ public class WatiApiService {
                 .headers(h -> h.addAll(headers))
                 .retrieve()
                 .bodyToMono(String.class)
-                .timeout(Duration.ofSeconds(25)) // Timeout de 8 segundos para respuestas ultra-rápidas
+                .timeout(Duration.ofSeconds(60)) // Timeout de 60 segundos para respuestas de Wati
                 .retryWhen(reactor.util.retry.Retry.backoff(1, Duration.ofMillis(500))) // 1 reintento con backoff ultra-rápido
                 .doOnSuccess(response -> System.out.println("WatiApiService: Mensaje enviado exitosamente. Respuesta de Wati: " + response))
                 .doOnError(error -> System.err.println("WatiApiService: Error al enviar mensaje a Wati: " + error.getMessage()))
@@ -94,7 +94,7 @@ public class WatiApiService {
                     .headers(h -> h.addAll(headers))
                     .retrieve()
                     .bodyToMono(String.class)
-                    .timeout(Duration.ofSeconds(25)) // Timeout de 8 segundos para respuestas ultra-rápidas
+                    .timeout(Duration.ofSeconds(60)) // Timeout de 60 segundos para respuestas de Wati
                     .retryWhen(reactor.util.retry.Retry.backoff(1, Duration.ofMillis(500))) // 1 reintento con backoff ultra-rápido
                     .doOnSuccess(resp -> System.out.println("WatiApiService: Mensaje síncrono enviado exitosamente. Respuesta de Wati: " + resp))
                     .doOnError(error -> System.err.println("WatiApiService: Error al enviar mensaje síncrono a Wati: " + error.getMessage()))


### PR DESCRIPTION
- Increase WatiApiService timeouts from 25s to 60s
- Increase WebClient timeouts from 25s to 60s
- Fixes 25s timeout errors causing service unresponsiveness
- Improves reliability when Wati API is slow
- Maintains performance while ensuring message delivery