### PR TITLE
fix: corregir configuración de SYSTEM_API_KEY para usar --set-secrets

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -197,13 +197,13 @@ jobs:
           echo "Configurando SYSTEM_API_KEY para PRODUCCIÓN..."
           gcloud run services update $SERVICE_NAME \
             --region=${{ env.REGION }} \
-            --set-env-vars SYSTEM_API_KEY=SYSTEM_API_KEY_PROD:latest
+            --set-secrets SYSTEM_API_KEY=SYSTEM_API_KEY_PROD:latest
         else
           # DESARROLLO
           echo "Configurando SYSTEM_API_KEY para DESARROLLO..."
           gcloud run services update $SERVICE_NAME \
             --region=${{ env.REGION }} \
-            --set-env-vars SYSTEM_API_KEY=SYSTEM_API_KEY_DEV:latest
+            --set-secrets SYSTEM_API_KEY=SYSTEM_API_KEY_DEV:latest
         fi
           
     - name: Get service URL


### PR DESCRIPTION
- Cambiar --set-env-vars por --set-secrets para SYSTEM_API_KEY
- Resolver issue donde SYSTEM_API_KEY no se configuraba en producción
- Garantizar que tanto DEV como PROD usen secretos correctos
- Corregir problema donde PROD usaba secreto de DEV o no se configuraba