### PR TITLE
feat: agregar protección de rama main en workflow CI/CD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main, dev ]
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
 
 env:
   PROJECT_ID: intreasoft-daniel
@@ -11,10 +14,24 @@ env:
   IMAGE_NAME: political-referrals-wa
 
 jobs:
+  # Job de Protección de Rama Main
+  protect-main-branch:
+    name: "Protect Main Branch"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - name: "Check base branch"
+        if: ${{ github.head_ref != 'dev' }}
+        run: |
+          echo "Error: Pull requests to main can only be made from the dev branch."
+          exit 1
+
   # Job de Build y Testing
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
+    needs: [protect-main-branch]
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.head_ref == 'dev')
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
- Agregar trigger para pull requests a main
- Crear job de protección que solo permite PRs desde rama dev
- Modificar build-and-test para depender de la protección
- Mantener flujo de trabajo seguro para despliegues