### PR TITLE
fix: simplificar needs del job build-and-test

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -31,7 +31,7 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
-    needs: ${{ (github.event_name == 'pull_request' && github.base_ref == 'main') && 'protect-main-branch' || '[]' }}
+    needs: []
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'dev'))
     
     steps:


### PR DESCRIPTION
- Eliminar expresión condicional compleja que causaba error
- Usar needs: [] para evitar dependencias problemáticas
- Mantener lógica de ejecución en if statement