### PR TITLE
fix: eliminar workflow_dispatch y simplificar triggers

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,7 +3,6 @@ name: CI/CD Pipeline - Political Referrals WA
 on:
   push:
     branches: [ main, dev ]
-  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -15,27 +14,11 @@ env:
   IMAGE_NAME: political-referrals-wa
 
 jobs:
-  # Job de Validación de Rama
-  validate-branch:
-    name: "Validate Branch"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Check if workflow should run"
-        run: |
-          if [[ "${{ github.ref }}" != "refs/heads/main" && "${{ github.ref }}" != "refs/heads/dev" ]]; then
-            echo "Error: This workflow only runs on main and dev branches."
-            echo "Current branch: ${{ github.ref }}"
-            echo "Skipping workflow execution."
-            exit 1
-          fi
-          echo "Branch validation passed. Continuing workflow execution."
-
   # Job de Protección de Rama Main
   protect-main-branch:
     name: "Protect Main Branch"
     runs-on: ubuntu-latest
-    needs: [validate-branch]
-    if: (github.event_name == 'pull_request' && github.base_ref == 'main') || (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'))
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
     steps:
       - name: "Check base branch"
         if: ${{ github.head_ref != 'dev' }}
@@ -47,8 +30,7 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
-    needs: [validate-branch]
-    if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')) || (github.event_name == 'pull_request' && (github.base_ref == 'main' || github.base_ref == 'dev')) || (github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'))
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
- Remover workflow_dispatch que permitía ejecución desde cualquier rama
- Eliminar job de validación innecesario
- Simplificar condiciones de ejecución
- Ahora solo se ejecuta en push a main/dev y PRs a main/dev