### PR TITLE
fix: hacer que build-and-test dependa de protect-main-branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,7 +36,8 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    needs: [protect-main-branch]
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main' && github.head_ref == 'dev')
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
- Agregar needs: [protect-main-branch] para asegurar validación
- Solo ejecutar build-and-test en PRs válidos (dev -> main)
- Evitar que se ejecute workflow completo en PRs inválidos