### PR TITLE
fix: permitir que build-and-test se ejecute en PRs hacia dev

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,8 +40,8 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
-    needs: [protect-main-branch]
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.base_ref == 'main')
+    needs: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' && 'protect-main-branch' || '[]' }}
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
- Corregir lógica de needs para que solo dependa de protect-main-branch en PRs a main
- Permitir que PRs hacia dev se ejecuten sin restricciones de rama de origen
- Ahora dev acepta PRs desde cualquier rama feature