### PR TITLE
fix: simplificar needs del job build-and-test para evitar errores

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,7 +40,7 @@ jobs:
   build-and-test:
     name: Build and Test
     runs-on: ubuntu-latest
-    needs: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' && 'protect-main-branch' || '[]' }}
+    needs: []
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     
     steps:


### PR DESCRIPTION
- Cambiar needs complejo por needs: [] simple
- Mantener lógica de ejecución en if statement
- Evitar errores de sintaxis en GitHub Actions